### PR TITLE
Longer refresh timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Agama Integration Tests
 
+[![CI](https://github.com/agama-project/integration-tests/actions/workflows/ci.yml/badge.svg)](https://github.com/agama-project/integration-tests/actions/workflows/ci.yml)
+[![CI - Integration Tests](https://github.com/agama-project/agama/actions/workflows/ci-integration-tests.yml/badge.svg)](https://github.com/agama-project/agama/actions/workflows/ci-integration-tests.yml)
+
 This is repository contains support for writing integration tests for Agama and few example tests.
 
 It uses the [Puppeteer](https://pptr.dev/) library for driving and communicating with a web browser.

--- a/src/test_root_password.ts
+++ b/src/test_root_password.ts
@@ -30,7 +30,8 @@ describe("Agama test", function () {
   optionalProductSelection("openSUSE Tumbleweed");
 
   it("should display overview card", async function () {
-    await page.waitForSelector("main ::-p-text('Overview')");
+    // refreshing the repositories might take long time, explicitly use a longer timeout
+    await page.waitForSelector("main ::-p-text('Overview')", { timeout: 60_000 });
   });
 
   setRootPassword("test");


### PR DESCRIPTION
## Problem

- The latest run failed [because of a timeout](https://github.com/agama-project/agama/actions/runs/13627995441/job/38089289718#step:18:45)

## Screenshot from CI

The screenshot shows that after 20 seconds the repository refresh has been just finished and the software proposal is being evaluated.

![should_display_overview_card](https://github.com/user-attachments/assets/c77b3f8c-9c4d-48aa-8c46-44e9f1a7507d)

## Solution

Refreshing the Tumbleweed repositories might take long time, the default 20 seconds might not be enough. Explicitly set 1 minute timeout for this check.