### PR TITLE
Fix OBS submission

### DIFF
--- a/.github/workflows/obs-submit.yml
+++ b/.github/workflows/obs-submit.yml
@@ -5,10 +5,6 @@ on:
   push:
     branches:
       - main
-      - release
-    # runs when creating a release tag
-    tags:
-      - v[0-9]*
 
   # allow running manually
   workflow_dispatch:

--- a/package/_service
+++ b/package/_service
@@ -1,10 +1,6 @@
 <services>
   <service name="obs_scm" mode="manual">
-    <!-- FIXME: there is no version tag yet, update the versioning after
-    creating the first version tag -->
-    <!-- <param name="versionformat">@PARENT_TAG@+@TAG_OFFSET@</param> -->
-    <!-- <param name="versionrewrite-pattern">v(.*)</param> -->
-    <param name="versionformat">%ct</param>
+    <param name="versionformat">%ct.%h</param>
     <!-- the URL is modified by the
     https://github.com/agama-project/agama/.github/workflows/obs-staging-shared.yml
     action when submitting to OBS -->
@@ -26,10 +22,10 @@
     <param name="source-offset">1000</param>
   </service>
   <service mode="buildtime" name="tar">
-    <param name="obsinfo">agama-integration-tests.obsinfo</param>
-    <param name="filename">agama-integration-tests</param>
+    <param name="obsinfo">agama.obsinfo</param>
+    <param name="filename">agama</param>
   </service>
   <service mode="buildtime" name="set_version">
-    <param name="basename">agama-integration-tests</param>
+    <param name="basename">agama</param>
   </service>
 </services>


### PR DESCRIPTION
## Problem

- Submission to OBS does not work

## Solution

- The main problem was missing `$OBS_PROJECTS` environment variable in the CI setup which is required by the shared job definition in [obs-staging-shared.yml](https://github.com/agama-project/agama/blob/master/.github/workflows/obs-staging-shared.yml#L35-L38). This resulted in [skipping the job](https://github.com/agama-project/integration-tests/actions/runs/30536739812/job/90851728782).
- However, after adding it [still did not work properly](https://github.com/agama-project/integration-tests/actions/runs/30816901303/job/91696803102#step:13:9). That shared CI job expects `agama.obsinfo` file used in the OBS package. That name is used for all Agama packages, so use it here as well.

## Additional changes

- Append a short commit hash to the package version to easily find the exact git sources for a built RPM package.
- We do not use the Git version tags in this repository so cleanup the CI definition