### PR TITLE
Fixed submission to OBS

### DIFF
--- a/package/_service
+++ b/package/_service
@@ -10,7 +10,7 @@
     https://github.com/agama-project/agama/.github/workflows/obs-staging-shared.yml
     action when submitting to OBS -->
     <param name="revision">main</param>
-    <param name="filename">agama-integration-tests</param>
+    <param name="filename">agama</param>
     <param name="without-version">enable</param>
     <param name="extract">package-lock.json</param>
     <param name="extract">package/agama-integration-tests.changes</param>


### PR DESCRIPTION
## Problem

- Submitting the package to OBS [fails](https://github.com/agama-project/integration-tests/actions/runs/30827904684/job/91734172312#step:13:10).

## Solution

- Create `agama.obs{info,cpio}` files by the OBS service as expected by the shared CI job (instead of the current `agama-integration-tests.obs{info,cpio}`).